### PR TITLE
fix: prefer /config volume over HOME when writing config in Docker

### DIFF
--- a/internal/config/write.go
+++ b/internal/config/write.go
@@ -51,11 +51,17 @@ func writeAtomic(path string, data []byte, perm os.FileMode) error {
 func WriteConfigKey(configFile, key, value string) (writePath string, err error) {
 	path := configFile
 	if path == "" {
-		home, _ := os.UserHomeDir()
-		if home != "" {
-			path = filepath.Join(home, ".config", "luminarr", "config.yaml")
-		} else {
+		// Mirror Load()'s search order: prefer /config (Docker volume mount) when
+		// the directory exists, then fall back to $HOME/.config/luminarr/.
+		if _, err := os.Stat("/config"); err == nil {
 			path = "/config/config.yaml"
+		} else {
+			home, _ := os.UserHomeDir()
+			if home != "" {
+				path = filepath.Join(home, ".config", "luminarr", "config.yaml")
+			} else {
+				path = "/config/config.yaml"
+			}
 		}
 	}
 

--- a/internal/config/write_test.go
+++ b/internal/config/write_test.go
@@ -1,0 +1,76 @@
+package config_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/luminarr/luminarr/internal/config"
+)
+
+func TestWriteConfigKey_ExplicitPath(t *testing.T) {
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "config.yaml")
+
+	path, err := config.WriteConfigKey(cfgFile, "auth.api_key", "test-key")
+	if err != nil {
+		t.Fatalf("WriteConfigKey() error = %v", err)
+	}
+	if path != cfgFile {
+		t.Errorf("returned path = %q, want %q", path, cfgFile)
+	}
+
+	raw, err := os.ReadFile(cfgFile)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if !strings.Contains(string(raw), "test-key") {
+		t.Errorf("config file does not contain written value; got:\n%s", raw)
+	}
+}
+
+func TestWriteConfigKey_PreservesExistingKeys(t *testing.T) {
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "config.yaml")
+
+	if err := os.WriteFile(cfgFile, []byte("server:\n  port: 9999\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := config.WriteConfigKey(cfgFile, "auth.api_key", "new-key"); err != nil {
+		t.Fatalf("WriteConfigKey() error = %v", err)
+	}
+
+	raw, err := os.ReadFile(cfgFile)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	content := string(raw)
+	if !strings.Contains(content, "9999") {
+		t.Errorf("existing key 'server.port' was lost; got:\n%s", content)
+	}
+	if !strings.Contains(content, "new-key") {
+		t.Errorf("new key 'auth.api_key' was not written; got:\n%s", content)
+	}
+}
+
+// TestWriteConfigKey_RoundTrip verifies that a key written by WriteConfigKey
+// can be read back by Load, confirming the write→load path is consistent.
+// This is the core invariant that was broken in the Docker restart bug.
+func TestWriteConfigKey_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "config.yaml")
+
+	if _, err := config.WriteConfigKey(cfgFile, "auth.api_key", "stable-key"); err != nil {
+		t.Fatalf("WriteConfigKey() error = %v", err)
+	}
+
+	cfg, err := config.Load(cfgFile)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.Auth.APIKey.Value() != "stable-key" {
+		t.Errorf("Load() Auth.APIKey = %q, want %q", cfg.Auth.APIKey.Value(), "stable-key")
+	}
+}


### PR DESCRIPTION
WriteConfigKey was writing the auto-generated API key to $HOME/.config/luminarr/config.yaml when $HOME was set, but Load() searches /config before $HOME. In Docker containers $HOME is typically /root, so the key landed in the ephemeral container layer rather than the mounted /config volume — causing a new key to be generated on every restart and invalidating all client sessions.

Fixes #2

Generated with [Claude Code](https://claude.ai/code)