### PR TITLE
Fix for Useless assignment to local variable

### DIFF
--- a/web/ui/src/pages/settings/libraries/LibraryList.tsx
+++ b/web/ui/src/pages/settings/libraries/LibraryList.tsx
@@ -1013,7 +1013,7 @@ function FileTableRow({
   const { file, selected, match, searchOpen, searchQuery, searchResults, importing, imported, autoMatchLoading, autoMatched } = row;
 
   // Row highlight colour.
-  let rowBg = "transparent";
+  let rowBg;
   if (imported) rowBg = "color-mix(in srgb, var(--color-success) 6%, transparent)";
   else if (match) rowBg = "color-mix(in srgb, var(--color-success) 8%, transparent)";
   else rowBg = "color-mix(in srgb, var(--color-warning) 5%, transparent)";


### PR DESCRIPTION
To fix the problem, remove the redundant initial assignment so that `rowBg` is only assigned within the conditional logic that actually determines its value. This eliminates dead code without changing functionality.

Concretely, in `FileTableRow` in `web/ui/src/pages/settings/libraries/LibraryList.tsx`, change the declaration of `rowBg` from `let rowBg = "transparent";` to just `let rowBg;`. The subsequent `if / else if / else` block always assigns `rowBg`, so TypeScript/JS will still have `rowBg` defined before use, and the runtime behavior of the component is unchanged. No new imports or helper methods are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._