### PR TITLE
Fix: show actual indexer name in releases tab

### DIFF
--- a/internal/core/indexer/service.go
+++ b/internal/core/indexer/service.go
@@ -263,7 +263,8 @@ func (s *Service) Search(ctx context.Context, query plugin.SearchQuery) ([]Searc
 			continue
 		}
 		for _, r := range res.releases {
-			// Fill in indexer name (plugin may have already set it, but ensure it).
+			// Prefer the per-item indexer name from Prowlarr/Jackett; fall back
+			// to the user-configured name from the database.
 			if r.Indexer == "" {
 				r.Indexer = res.indexerName
 			}

--- a/plugins/indexers/newznab/newznab.go
+++ b/plugins/indexers/newznab/newznab.go
@@ -207,7 +207,7 @@ func (idx *Indexer) toRelease(item rssItem) plugin.Release {
 	r := plugin.Release{
 		GUID:        guid,
 		Title:       item.Title,
-		Indexer:     idx.cfg.URL,
+		Indexer:     item.JackettIndexer, // Prowlarr fills this; empty for standalone indexers.
 		Protocol:    plugin.ProtocolNZB,
 		DownloadURL: item.Enclosure.URL,
 		InfoURL:     item.Link,
@@ -266,6 +266,8 @@ type rssItem struct {
 	Link      string    `xml:"link"`
 	PubDate   string    `xml:"pubDate"`
 	Enclosure enclosure `xml:"enclosure"`
+	// Prowlarr/Jackett include the upstream indexer name per item.
+	JackettIndexer string `xml:"jackettindexer"`
 	// Newznab attributes use the namespace http://www.newznab.com/DTD/2010/feeds/attributes/.
 	Attrs []newznabAttr `xml:"http://www.newznab.com/DTD/2010/feeds/attributes/ attr"`
 }

--- a/plugins/indexers/torznab/torznab.go
+++ b/plugins/indexers/torznab/torznab.go
@@ -233,7 +233,7 @@ func (idx *Indexer) toRelease(item rssItem) plugin.Release {
 	r := plugin.Release{
 		GUID:        guid,
 		Title:       item.Title,
-		Indexer:     idx.cfg.URL,
+		Indexer:     item.JackettIndexer, // Prowlarr fills this; empty for standalone indexers.
 		Protocol:    plugin.ProtocolTorrent,
 		DownloadURL: item.Enclosure.URL,
 		InfoURL:     item.Link,
@@ -297,6 +297,8 @@ type rssItem struct {
 	Link      string    `xml:"link"`
 	PubDate   string    `xml:"pubDate"`
 	Enclosure enclosure `xml:"enclosure"`
+	// Prowlarr/Jackett include the upstream indexer name per item.
+	JackettIndexer string `xml:"jackettindexer"`
 	// Torznab attributes use the namespace http://torznab.com/schemas/2015/feed.
 	Attrs []torznabAttr `xml:"http://torznab.com/schemas/2015/feed attr"`
 }

--- a/web/ui/src/components/IndexerPill.tsx
+++ b/web/ui/src/components/IndexerPill.tsx
@@ -1,0 +1,28 @@
+function indexerHue(name: string): number {
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) {
+    hash = name.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  return ((hash % 360) + 360) % 360;
+}
+
+export default function IndexerPill({ name }: { name: string }) {
+  const hue = indexerHue(name);
+  return (
+    <span
+      style={{
+        display: "inline-block",
+        padding: "2px 6px",
+        borderRadius: 4,
+        fontSize: 10,
+        fontWeight: 600,
+        letterSpacing: "0.03em",
+        background: `hsla(${hue}, 60%, 55%, 0.15)`,
+        color: `hsl(${hue}, 70%, 65%)`,
+        whiteSpace: "nowrap",
+      }}
+    >
+      {name}
+    </span>
+  );
+}

--- a/web/ui/src/components/ManualSearchModal.tsx
+++ b/web/ui/src/components/ManualSearchModal.tsx
@@ -3,6 +3,7 @@ import { useMovieReleases, useGrabRelease, type GrabReleaseRequest } from "@/api
 import type { Release } from "@/types";
 import { formatBytes } from "@/lib/utils";
 import ScoreChip from "@/components/ScoreChip";
+import IndexerPill from "@/components/IndexerPill";
 
 // ── Quality badge ─────────────────────────────────────────────────────────────
 
@@ -77,7 +78,7 @@ function ReleaseRow({ release, grabbed, grabError, onGrab, isPending }: ReleaseR
           {release.peers !== undefined && (
             <span style={{ fontSize: 11, color: "var(--color-text-muted)" }}>↓{release.peers}</span>
           )}
-          <span style={{ fontSize: 11, color: "var(--color-text-muted)" }}>{release.indexer}</span>
+          <IndexerPill name={release.indexer} />
           {release.age_days !== undefined && release.age_days > 0 && (
             <span style={{ fontSize: 11, color: "var(--color-text-muted)" }}>
               {Math.round(release.age_days)}d old

--- a/web/ui/src/pages/movies/MovieDetail.tsx
+++ b/web/ui/src/pages/movies/MovieDetail.tsx
@@ -20,6 +20,7 @@ import {
 } from "@/api/movies";
 import { ManualSearchModal } from "@/components/ManualSearchModal";
 import ScoreChip from "@/components/ScoreChip";
+import IndexerPill from "@/components/IndexerPill";
 import type { Release, RenamePreviewItem, TMDBResult, MediaInfo, Quality } from "@/types";
 import { formatBytes } from "@/lib/utils";
 import { useMediainfoStatus, useScanMovieFile } from "@/api/mediainfo";
@@ -219,9 +220,7 @@ function ReleaseRow({ release, grabbed, grabError, onGrab, isPending }: ReleaseR
               ↓{release.peers}
             </span>
           )}
-          <span style={{ fontSize: 11, color: "var(--color-text-muted)" }}>
-            {release.indexer}
-          </span>
+          <IndexerPill name={release.indexer} />
           {release.age_days !== undefined && release.age_days > 0 && (
             <span style={{ fontSize: 11, color: "var(--color-text-muted)" }}>
               {Math.round(release.age_days)}d old


### PR DESCRIPTION
## Summary
- Torznab/newznab plugins were setting `Release.Indexer` to the raw config URL instead of a meaningful name
- Now parses `<jackettindexer>` from Prowlarr/Jackett RSS responses to show the actual upstream indexer (e.g. "1337x", "IPTorrents")
- Falls back to user-configured indexer name for standalone instances
- Adds `IndexerPill` component with deterministic hash-based colors for visual distinction

## Test plan
- [ ] Search releases via Prowlarr — verify each release shows the upstream indexer name, not "Prowlarr" or a URL
- [ ] Search releases via standalone Torznab — verify the user-configured name is shown
- [ ] Confirm different indexers get distinct pill colors

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)