### PR TITLE
fix: use value types for Huma query params (pointer panic)

### DIFF
--- a/internal/api/v1/activity.go
+++ b/internal/api/v1/activity.go
@@ -10,9 +10,9 @@ import (
 )
 
 type listActivitiesInput struct {
-	Category *string `query:"category" doc:"Filter by category: grab, import, task, health, movie"`
-	Since    *string `query:"since"    doc:"Only return activities after this ISO 8601 timestamp"`
-	Limit    int64   `query:"limit"    doc:"Max results (default 100, max 500)" default:"100"`
+	Category string `query:"category" doc:"Filter by category: grab, import, task, health, movie"`
+	Since    string `query:"since"    doc:"Only return activities after this ISO 8601 timestamp"`
+	Limit    int64  `query:"limit"    doc:"Max results (default 100, max 500)" default:"100"`
 }
 
 type listActivitiesOutput struct {
@@ -29,11 +29,19 @@ func RegisterActivityRoutes(api huma.API, svc *activity.Service) {
 		Description: "Returns a chronological feed of system events: grabs, imports, task runs, health changes, and movie additions.",
 		Tags:        []string{"Activity"},
 	}, func(ctx context.Context, input *listActivitiesInput) (*listActivitiesOutput, error) {
-		if input.Category != nil && !activity.ValidCategory(*input.Category) {
+		if input.Category != "" && !activity.ValidCategory(input.Category) {
 			return nil, huma.NewError(http.StatusBadRequest, "invalid category: must be one of grab, import, task, health, movie")
 		}
 
-		result, err := svc.List(ctx, input.Category, input.Since, input.Limit)
+		var catPtr, sincePtr *string
+		if input.Category != "" {
+			catPtr = &input.Category
+		}
+		if input.Since != "" {
+			sincePtr = &input.Since
+		}
+
+		result, err := svc.List(ctx, catPtr, sincePtr, input.Limit)
 		if err != nil {
 			return nil, huma.NewError(http.StatusInternalServerError, "failed to list activities", err)
 		}


### PR DESCRIPTION
## Summary

Huma v2 does not support pointer types for query/path/header params — it panics on startup. The activity endpoint used `*string` for optional category and since filters. Changed to plain `string` with empty-string check.

## Test plan

- [x] `go build` passes
- [x] Pre-push lint + tsc pass
- [ ] App starts without panic

🤖 Generated with [Claude Code](https://claude.com/claude-code)